### PR TITLE
implements listen parameter

### DIFF
--- a/dataflake/wsgi/bjoern/__init__.py
+++ b/dataflake/wsgi/bjoern/__init__.py
@@ -45,6 +45,5 @@ def serve_paste(app, global_conf, **kw):
     else:
         reuse_port = False
 
-    import pdb; pdb.set_trace()
     run(app, host, port=port, reuse_port=reuse_port)
     return 0

--- a/dataflake/wsgi/bjoern/__init__.py
+++ b/dataflake/wsgi/bjoern/__init__.py
@@ -32,10 +32,19 @@ def serve_paste(app, global_conf, **kw):
     # Convert the values from the .ini file to something bjoern can work with
     host = kw.get('host', '')
     port = int(kw.get('port', '0')) or False
+    if not host and not port and kw.get('listen'):
+        listen = kw.get('listen')
+        if ':' in listen:
+            host = listen.split(':')[0]
+            port = int(listen.split(':')[1])
+        else:
+            host = ''
+            port = int(listen)
     if kw.get('reuse_port', '').lower() in ('1', 'true', 'on'):
         reuse_port = True
     else:
         reuse_port = False
 
+    import pdb; pdb.set_trace()
     run(app, host, port=port, reuse_port=reuse_port)
     return 0

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,6 +27,22 @@ IPv4 interfaces (`0.0.0.0`). If no port is specified ``bjoern`` will choose a
 random port (probably not what you want). ``reuse_port`` sets ``SO_REUSEPORT``
 if it is available on your platform.
 
+Alternatively you could use ``listen`` directive instead of ``host`` and ``port``:
+
+.. code-block:: ini
+
+   [server:main]
+   use = egg:dataflake.wsgi.bjoern#main
+   listen = 127.0.0.1:8080
+   reuse_port = True
+
+.. code-block:: ini
+
+   [server:main]
+   use = egg:dataflake.wsgi.bjoern#main
+   listen = 8080
+   reuse_port = True
+
 
 Creating a basic WSGI configuration for Zope
 --------------------------------------------


### PR DESCRIPTION
with listen parameter and https://github.com/plone/plone.recipe.zope2instance/pull/120, using bjoern as WSGI server with p.r.zope2instance could be more easy (no needs to run `bin/mkbjoerninstance`):

buildout.cfg:
```
[instance]
...
eggs =
      Plone
     dataflake.wsgi.bjoern
wsgi-ini-template = ${buildout:directory}/templates/bjoern.ini.in
```
bjoern.ini.in:
```
[server:main]
use = egg:dataflake.wsgi.bjoern#main
listen = %(http_address)s

[app:zope]
use = egg:Zope#main
zope_conf = %(location)s/etc/zope.conf

[filter:translogger]
use = egg:Paste#translogger
setup_console_handler = False

[pipeline:main]
pipeline =
    %(pipeline)s

[loggers]
keys = root, plone, bjoern, wsgi
...
```
